### PR TITLE
Implement subcommands

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Changelog
 * :feature:`7` Allow Tron connection to fail but keep the actor alive and working.
 * :bug:`11` Allow to pass parser arguments to a `.CluGroup`.
 * :bug:`8` Fix `AttributeError` when connection breaks.
+* :feature:`15` Implement subcommands.
 
 * :release:`0.1.3 <2019-10-11>`
 * Fix Travis deployment.


### PR DESCRIPTION
Fixes #15.

This is still a bit incomplete since it only allows to create a new `Command` with knowledge of its parent command, and prevents command_id collision. One key thing to decide is whether the child command should have the same command_id as the parent but not be allowed to modify the status of the command. For now this works and in most cases having a subcommand with `command_id=0` is ok (the `commander_id` is set to that of the parent so only that commander receives the output).