### PR TITLE
Rename Command done and failed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@
 Changelog
 =========
 
+* :feature:`21` Renamed ``Command.done`` and ``.failed`` to `.Command.finish` and `.Command.fail`.
+
 * :release:`0.1.12 <2020-01-14>`
 * Some tweaks to `.JSONActor` and the testing framework.
 * Added an error reply level.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sdss-clu"
-version = "0.1.13-alpha.0"
+version = "0.2.0-alpha.0"
 description = "A new protocol for SDSS actors."
 authors = ["José Sánchez-Gallego <gallegoj@uw.edu>"]
 license = "BSD-3-Clause"

--- a/python/clu/command.py
+++ b/python/clu/command.py
@@ -142,12 +142,12 @@ class BaseCommand(asyncio.Future, StatusMixIn):
             if self.watcher is not None:
                 self.watcher.set()
 
-    def done(self, *args, **kwargs):
+    def finish(self, *args, **kwargs):
         """Convenience method to mark a command `~.CommandStatus.DONE`."""
 
         self.set_status(CommandStatus.DONE, *args, **kwargs)
 
-    def failed(self, *args, **kwargs):
+    def fail(self, *args, **kwargs):
         """Convenience method to mark a command `~.CommandStatus.FAILED`."""
 
         self.set_status(CommandStatus.FAILED, *args, **kwargs)


### PR DESCRIPTION
Fixes #21.

Bumped version to 0.2.0 because it's a breaking change, although since CLU is still in beta, we don't want to bump to 1.0.