### PR TITLE
Add url and virtualhost parameters for AMQP connection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 =========
 
 * :bug:`-` Fix AMQP CLI. It failed when printing a message code ``>`` as HTML.
+* :bug:`44` Add ``url``, ``virtualhost``, and ``ssl`` parameters for `.AMQPClient` that propagates to `.TopicListener`. When defined ``url`` overrides the connection parameters. The CLU CLI now also accepts a ``--url`` flag.
 
 * :release:`0.5.4 <2020-11-05>`
 * :bug:`-` Fix typo that caused `.Device.stop` to fail.

--- a/python/clu/__main__.py
+++ b/python/clu/__main__.py
@@ -78,9 +78,10 @@ class ShellClient(clu.AMQPClient):
             print()  # Newline
 
 
-async def shell_client_prompt(user=None, password=None, host=None, port=None):
+async def shell_client_prompt(url=None, user=None, password=None,
+                              host=None, port=None):
 
-    client = await ShellClient('shell_client',
+    client = await ShellClient('shell_client', url=url,
                                user=user, password=password,
                                host=host, port=port,
                                log=False).start()
@@ -115,6 +116,8 @@ async def shell_client_prompt(user=None, password=None, host=None, port=None):
 
 
 @click.command(name='clu')
+@click.option('--url', type=str,
+              help='AMQP RFC3986 formatted broker address.')
 @click.option('--user', '-U', type=str, show_default=True, default='guest',
               help='The AMQP username.')
 @click.option('--password', '-U', type=str, show_default=True, default='guest',
@@ -123,12 +126,13 @@ async def shell_client_prompt(user=None, password=None, host=None, port=None):
               help='The host running the AMQP server.')
 @click.option('--port', '-P', type=int, show_default=True, default=5672,
               help='The port on which the server is running')
-def clu_cli(user, password, host, port):
+def clu_cli(url, user, password, host, port):
     """Runs the AMQP command line interpreter."""
 
     with patch_stdout():
 
-        shell_task = loop.create_task(shell_client_prompt(user=user,
+        shell_task = loop.create_task(shell_client_prompt(url=url,
+                                                          user=user,
                                                           password=password,
                                                           host=host,
                                                           port=port))

--- a/python/clu/client.py
+++ b/python/clu/client.py
@@ -113,14 +113,21 @@ class AMQPClient(BaseClient):
     ----------
     name : str
         The name of the actor.
+    url : str
+        RFC3986 formatted broker address. When used, the other connection
+        keyword arguments are ignored.
     user : str
         The user to connect to the AMQP broker. Defaults to ``guest``.
     password : str
         The password for the user. Defaults to ``guest``.
     host : str
         The host where the AMQP message broker runs. Defaults to ``localhost``.
+    virtualhost : str
+         Virtualhost parameter. ``'/'`` by default.
     port : int
         The port on which the AMQP broker is running. Defaults to 5672.
+    ssl : bool
+        Whether to use TLS/SSL connection.
     version : str
         The version of the actor.
     loop
@@ -143,23 +150,20 @@ class AMQPClient(BaseClient):
 
     connection = None
 
-    def __init__(self, name, user=None, password=None, host=None, port=None,
-                 version=None, loop=None, log_dir=None, log=None,
-                 models=None):
+    def __init__(self, name, url=None, user='guest', password='guest',
+                 host='localhost', port=5672, virtualhost='/', ssl=False,
+                 version=None, loop=None, log_dir=None, log=None, models=None):
 
         super().__init__(name, version=version, loop=loop,
                          log_dir=log_dir, log=log)
 
-        self.user = user or 'guest'
-        self.password = password or 'guest'
-        self.host = host or 'localhost'
-        self.port = port or 5672
-
         self.replies_queue = None
 
         # Creates the connection to the AMQP broker
-        self.connection = TopicListener(self.user, self.password,
-                                        self.host, port=self.port)
+        self.connection = TopicListener(url=url, user=user,
+                                        password=password,
+                                        host=host, port=port,
+                                        ssl=ssl, virtualhost=virtualhost)
 
         #: dict: External commands currently running.
         self.running_commands = {}

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -11,7 +11,9 @@ import asyncio
 import pytest
 
 from clu.protocol import (TCPStreamClient, TCPStreamPeriodicServer,
-                          TCPStreamServer, open_connection)
+                          TCPStreamServer, TopicListener, open_connection)
+
+from .conftest import RMQ_PORT
 
 
 pytestmark = [pytest.mark.asyncio]
@@ -67,3 +69,16 @@ async def test_periodic_server(unused_tcp_port_factory, mocker):
     callback.assert_called()
 
     periodic_server.stop()
+
+
+async def test_topic_listener_url(amqp_actor):
+
+    url = f'amqp://guest:guest@localhost:{RMQ_PORT}'
+    exchange = 'test'
+
+    listener = TopicListener(url)
+    await listener.connect(exchange)
+
+    assert listener.connection.connected.is_set()
+
+    await listener.stop()


### PR DESCRIPTION
Fixes #44.

Introduces `url`, `virtualhost`, and `ssl` parameters for `AMQPClient` that propagate to `TopicListener`. When defined `url` overrides the connection parameters. The CLU CLI now also accepts a `--url` flag.