### PR TITLE
Store replies in Command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@
 Changelog
 =========
 
+* :feature:`48` `.BaseActor.write` now processes the reply regardless of the specific actor implementation and creates a `.Reply`. The `.Reply` is passed to the actor ``_write_internal`` implementation which handles sending it to the users using the specific actor transport. If the reply has been created by a command, the `.Reply` object is appended to `.BaseCommand.replies`.
+
 * :release:`0.6.3 <2021-02-16>`
 * :feature:`-` The JSONSchema ``array`` type now allows both Python ``list`` and ``tuple``.
 * :support:`-` Renamed ``no_validate`` in actors ``write`` method to ``validate`` (defaults to ``True`` so the behaviour should not change).

--- a/docs/sphinx/api.rst
+++ b/docs/sphinx/api.rst
@@ -9,6 +9,7 @@ Base classes
 
 .. autoclass:: clu.base.BaseClient
 .. autoclass:: clu.base.BaseActor
+.. autoclass:: clu.base.Reply
 
 
 Client

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = "aio-pika"
-version = "6.7.1"
+version = "6.8.0"
 description = "Wrapper for the aiormq for asyncio and humans."
 category = "main"
 optional = false
@@ -1115,8 +1115,8 @@ content-hash = "f13183a3105d0dbfbabe6d0a3705cd030265dcf9e51413f7e36790fb5d0c4317
 
 [metadata.files]
 aio-pika = [
-    {file = "aio-pika-6.7.1.tar.gz", hash = "sha256:9773440a89840941ac3099a7720bf9d51e8764a484066b82ede4d395660ff430"},
-    {file = "aio_pika-6.7.1-py3-none-any.whl", hash = "sha256:a8065be3c722eb8f9fff8c0e7590729e7782202cdb9363d9830d7d5d47b45c7c"},
+    {file = "aio-pika-6.8.0.tar.gz", hash = "sha256:1d4305a5f78af3857310b4fe48348cdcf6c097e0e275ea88c2cd08570531a369"},
+    {file = "aio_pika-6.8.0-py3-none-any.whl", hash = "sha256:e69afef8695f47c5d107bbdba21bdb845d5c249acb3be53ef5c2d497b02657c0"},
 ]
 aiormq = [
     {file = "aiormq-3.3.1-py3-none-any.whl", hash = "sha256:e584dac13a242589aaf42470fd3006cb0dc5aed6506cbd20357c7ec8bbe4a89e"},

--- a/python/clu/actor.py
+++ b/python/clu/actor.py
@@ -14,7 +14,7 @@ import pathlib
 import re
 import uuid
 
-from typing import Any, Dict, Optional, TypeVar, Union
+from typing import Any, Dict, Optional, TypeVar, Union, cast
 
 import aio_pika as apika
 import click
@@ -363,7 +363,7 @@ class JSONActor(ClickParser, BaseActor):
             transport.write(message_json.encode())
 
         message = reply.message
-        command = reply.command
+        command = cast(Command, reply.command)
 
         commander_id = command.commander_id if command else None
         command_id = command.command_id if command else None

--- a/python/clu/client.py
+++ b/python/clu/client.py
@@ -220,7 +220,9 @@ class AMQPClient(BaseClient):
 
         # Binds the replies queue.
         self.replies_queue = await self.connection.add_queue(
-            f"{self.name}_replies", callback=self.handle_reply, bindings=["reply.#"]
+            f"{self.name}_replies",
+            callback=self.handle_reply,
+            bindings=["reply.#"],
         )
 
         self.log.info(

--- a/python/clu/command.py
+++ b/python/clu/command.py
@@ -13,7 +13,7 @@ import re
 import time
 from contextlib import suppress
 
-from typing import Any, Awaitable, Callable, Dict, Optional, Tuple, Union
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, Union
 
 import clu
 import clu.base
@@ -88,8 +88,8 @@ class BaseCommand(asyncio.Future, StatusMixIn[CommandStatus]):
         self.default_keyword = default_keyword
         self.loop = loop or asyncio.get_event_loop()
 
-        #: A list of replies this command has received.
-        self.replies = []
+        #: ~clu.base.Reply: A list of replies this command has received.
+        self.replies: List[clu.base.Reply] = []
 
         asyncio.Future.__init__(self, loop=self.loop)
 
@@ -210,7 +210,7 @@ class BaseCommand(asyncio.Future, StatusMixIn[CommandStatus]):
     def write(
         self,
         message_code: str = "i",
-        message: Dict[str, Any] = None,
+        message: Optional[Union[Dict[str, Any], str]] = None,
         broadcast: bool = False,
         **kwargs,
     ):
@@ -241,16 +241,13 @@ class BaseCommand(asyncio.Future, StatusMixIn[CommandStatus]):
 
         command = self if not self.parent else self.parent
 
-        result: Optional[Awaitable[Any]] = self.actor.write(
+        self.actor.write(
             message_code,
             message=message,
             command=command,
             broadcast=broadcast,
             **kwargs,
         )
-
-        if result and asyncio.iscoroutine(result):
-            self.loop.create_task(result)
 
 
 class Command(BaseCommand):

--- a/python/clu/command.py
+++ b/python/clu/command.py
@@ -13,7 +13,7 @@ import re
 import time
 from contextlib import suppress
 
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import clu
 import clu.base
@@ -88,7 +88,7 @@ class BaseCommand(asyncio.Future, StatusMixIn[CommandStatus]):
         self.default_keyword = default_keyword
         self.loop = loop or asyncio.get_event_loop()
 
-        #: ~clu.base.Reply: A list of replies this command has received.
+        #: .Reply: A list of replies this command has received.
         self.replies: List[clu.base.Reply] = []
 
         asyncio.Future.__init__(self, loop=self.loop)

--- a/python/clu/legacy/actor.py
+++ b/python/clu/legacy/actor.py
@@ -413,7 +413,7 @@ class BaseLegacyActor(BaseActor):
     def _write_internal(self, reply: Reply, user_id=0, command_id=0, concatenate=True):
         """Writes reply to users."""
 
-        command = reply.command
+        command = cast(Command, reply.command)
         message = reply.message
 
         # For a reply, the commander ID is the user assigned to the transport

--- a/python/clu/legacy/actor.py
+++ b/python/clu/legacy/actor.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List, Optional, Tuple, TypeVar, Union, cast
 import clu
 
 from ..actor import CustomTransportType
-from ..base import BaseActor
+from ..base import BaseActor, Reply
 from ..command import Command, TimedCommandList, parse_legacy_command
 from ..parser import ClickParser
 from ..protocol import TCPStreamServer
@@ -341,7 +341,7 @@ class BaseLegacyActor(BaseActor):
                 commander=f"{self.name}.{self.name}",
                 mid=command_id,
             )
-            command.actor = self
+            # command.actor = self
             return command
 
         else:
@@ -392,33 +392,44 @@ class BaseLegacyActor(BaseActor):
             supersedes ``message``.
         """
 
+        reply = BaseActor.write(
+            self,
+            message_code=message_code,
+            message=message,
+            command=command,
+            broadcast=broadcast,
+            validate=validate,
+            call_internal=False,
+            **kwargs,
+        )
+
+        self._write_internal(
+            reply,
+            user_id=user_id,
+            command_id=command_id,
+            concatenate=concatenate,
+        )
+
+    def _write_internal(self, reply: Reply, user_id=0, command_id=0, concatenate=True):
+        """Writes reply to users."""
+
+        command = reply.command
+        message = reply.message
+
         # For a reply, the commander ID is the user assigned to the transport
         # that issues this command.
         transport = command.transport if command else None
         user_id = (transport.user_id if transport else None) or user_id
 
-        if broadcast:
+        if reply.broadcast:
             user_id = 0
             command_id = 0
 
         user_id, command_id = self.get_user_command_id(
-            command=command, user_id=user_id, command_id=command_id
+            command=command,
+            user_id=user_id,
+            command_id=command_id,
         )
-
-        if message is None or (isinstance(message, str) and message.strip() == ""):
-            message = {}
-        elif isinstance(message, str):
-            message = {"text": message}
-        elif not isinstance(message, dict):
-            raise TypeError("invalid message type " + str(type(message)))
-
-        if validate and hasattr(self, "model") and self.model is not None:
-            result, err = self.model.update_model(message)
-            if result is False:
-                message = {"error": f"Failed validating the reply: {err}"}
-                message_code = "e"
-
-        message.update(kwargs)
 
         lines = []
         for keyword in message:
@@ -432,9 +443,11 @@ class BaseLegacyActor(BaseActor):
             lines = ["; ".join(lines)]
 
         for line in lines:
-
             full_msg_str = self.format_user_output(
-                user_id, command_id, message_code, line
+                user_id,
+                command_id,
+                reply.message_code,
+                line,
             )
             msg = (full_msg_str + "\n").encode()
 
@@ -445,7 +458,7 @@ class BaseLegacyActor(BaseActor):
                 transport.write(msg)
 
             if self.log:
-                log_reply(self.log, message_code, full_msg_str)
+                log_reply(self.log, reply.message_code, full_msg_str)
 
 
 class LegacyActor(ClickParser, BaseLegacyActor):

--- a/python/clu/legacy/types/keys.py
+++ b/python/clu/legacy/types/keys.py
@@ -487,11 +487,11 @@ class KeysDictionary(object):
             return kdict
         except ImportError as e:
             raise KeysDictionaryError(
-                "no keys dictionary found " "for %s: %s" % (dictname, str(e))
+                "no keys dictionary found for %s: %s" % (dictname, str(e))
             )
         except Exception as e:
             indent = "\n >> "
             description = indent + indent.join(str(e).split("\n"))
             raise KeysDictionaryError(
-                "badly formatted keys " "dictionary in %s:%s" % (dictname, description)
+                "badly formatted keys dictionary in %s:%s" % (dictname, description)
             )

--- a/python/clu/protocol.py
+++ b/python/clu/protocol.py
@@ -339,7 +339,7 @@ class TCPStreamClient:
         if self.writer:
             self.writer.close()
         else:
-            raise RuntimeError("connection cannot be closed " "because it is not open.")
+            raise RuntimeError("connection cannot be closed because it is not open.")
 
 
 async def open_connection(host: str, port: int) -> TCPStreamClient:

--- a/python/clu/testing.py
+++ b/python/clu/testing.py
@@ -160,7 +160,7 @@ async def setup_test_actor(actor: T, user_id: int = 1) -> T:
 
     if not issubclass(actor.__class__, (clu.LegacyActor, clu.JSONActor)):
         raise RuntimeError(
-            "setup_test_actor is only usable with " "LegacyActor or JSONActor actors."
+            "setup_test_actor is only usable with LegacyActor or JSONActor actors."
         )
 
     def invoke_mock_command(self, command_str, command_id=0):

--- a/tests/legacy/conftest.py
+++ b/tests/legacy/conftest.py
@@ -54,7 +54,9 @@ async def tron_server(unused_tcp_port_factory):
             transport.write(reply.encode())
 
     server = TCPStreamServer(
-        "localhost", unused_tcp_port_factory(), data_received_callback=echo
+        "localhost",
+        unused_tcp_port_factory(),
+        data_received_callback=echo,
     )
 
     server.received = received

--- a/tests/legacy/test_actor.py
+++ b/tests/legacy/test_actor.py
@@ -174,7 +174,9 @@ async def test_command_failed_to_parse(actor, actor_client):
 async def test_write_update_model_fails(actor, actor_client, mocker):
 
     mocker.patch.object(
-        actor.model, "update_model", return_value=(False, "failed updating model.")
+        actor.model,
+        "update_model",
+        return_value=(False, "failed updating model."),
     )
 
     actor.transports[1] = mocker.MagicMock()
@@ -182,7 +184,7 @@ async def test_write_update_model_fails(actor, actor_client, mocker):
     actor.write("i", {"text": "Some message"})
 
     actor.transports[1].write.assert_called_with(
-        b'0 0 e error="Failed validating the reply: ' b'failed updating model."\n'
+        b'0 0 e error="Failed validating the reply: failed updating model."\n'
     )
 
 

--- a/tests/legacy/test_tron.py
+++ b/tests/legacy/test_tron.py
@@ -42,7 +42,7 @@ async def test_update_model(tron_client, tron_server):
     assert act_alert.value[1] == "Alert2"
     assert act_alert.key[1].name == "alertID"
 
-    assert repr(act_alert) == ("<TronKey (activeAlerts): " "['Alert1', 'Alert2']>")
+    assert repr(act_alert) == ("<TronKey (activeAlerts): ['Alert1', 'Alert2']>")
 
 
 async def test_parser_fails(tron_client, tron_server, caplog, mocker):
@@ -88,7 +88,7 @@ async def test_send_command(actor, tron_server):
 
     assert b"test_actor.test_actor" in tron_server.received[-1]
     assert b"alerts ping" in tron_server.received[-1]
-
+    print(command.replies)
     assert len(command.replies) == 1
 
 

--- a/tests/test_actor_json.py
+++ b/tests/test_actor_json.py
@@ -11,6 +11,8 @@ import json
 
 import pytest
 
+from clu.command import Command
+
 
 pytestmark = [pytest.mark.asyncio]
 
@@ -22,6 +24,20 @@ async def test_json_actor(json_actor, json_client):
 
     assert json_actor.server.is_serving()
     assert len(json_actor.transports) == 1
+
+
+async def test_json_actor_command_write(json_actor, json_client):
+
+    command = Command(
+        command_string="ping",
+        actor=json_actor,
+    )
+
+    command.set_status("RUNNING")
+    command.write("i", text="Pong")
+
+    assert len(command.replies) == 2
+    assert command.replies[0].message_code == ">"
 
 
 async def test_json_actor_pong(json_client):
@@ -103,7 +119,9 @@ async def test_timed_command(json_actor, json_client):
 async def test_write_update_model_fails(json_actor, json_client, mocker):
 
     mocker.patch.object(
-        json_actor.model, "update_model", return_value=(False, "failed updating model.")
+        json_actor.model,
+        "update_model",
+        return_value=(False, "failed updating model."),
     )
 
     json_actor.transports["mock_transport"] = mocker.MagicMock()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -163,17 +163,16 @@ async def test_command_neg_number(json_actor, click_parser, command_string):
     await cmd
 
     assert cmd.status.did_succeed
-
     # This is a different test. We are testing that mygroup got called
     # with the parser_obj "object" and its value was passed.
-    assert cmd.replies[-2]["object"] == "my_object"
+    assert cmd.replies[-3]["object"] == "my_object"
 
     if "-15" in command_string:
-        assert cmd.replies[-1]["value"] == -15
+        assert cmd.replies[-2]["value"] == -15
     else:
-        assert cmd.replies[-1]["value"] == 15
+        assert cmd.replies[-2]["value"] == 15
 
     if "-r" in command_string or "--recursive" in command_string:
-        assert cmd.replies[-1]["recursive"] is True
+        assert cmd.replies[-2]["recursive"] is True
     else:
-        assert cmd.replies[-1]["recursive"] is False
+        assert cmd.replies[-2]["recursive"] is False


### PR DESCRIPTION
Fixes #48

- ``BaseActor.write`` now implements the logic of merging ``message`` with ``kwargs``, updating the model, validating the message, etc. It produces a ``Reply`` instance that is then passed to the actor particular implementation of ``_write_internal()``. ``write`` is always a function; ``_write_internal`` may be a coroutine, in which case ``write`` schedules it as a task.
- If ``write`` has been called from a ``Command``, the reply is appended to ``Command.replies``.