### PR TITLE
Add TCPBaseActor

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 =========
 
 * :feature:`70` Add a new :ref:`json-parser` that receives a JSON command string that can be unpacked into a dictionary. The dictionary is then passed to the callback. This parser can be used for actors that won't be directly addressed by a user on a command line interface and it simplifies passing complex arguments to a command callback. The parser have been rearranged and compiled in the ``clu.parsers`` submodule so this can be a breaking changes for code that used advanced functions directly from the old ``clu.parser`` module. Also adds a `.AMQPBaseActor` that does not explicitely include a parser; `.AMQPActor` still uses the Click parser.
+* :feature:`72` Add a new `.TCPBaseActor` which is the same as the old `.JSONActor` but without a parser implementation. `.JSONActor` is now the implementation of the base TCP actor with a Click parser. `.TCPBaseActor` can be used to implement any actor that receives commands over a normal TCP socket.
 
 * :release:`0.7.8 <2021-04-08>`
 * :bug:`-` Fix parsing of command strings in which parameters were a string with spaces. For example ``command --value "A value"`` would fail because it would be split into arguments without respeting the quoted string.

--- a/docs/sphinx/api.rst
+++ b/docs/sphinx/api.rst
@@ -23,6 +23,7 @@ Actor
 
 .. autoclass:: clu.actor.AMQPBaseActor
 .. autoclass:: clu.actor.AMQPActor
+.. autoclass:: clu.actor.TCPBaseActor
 .. autoclass:: clu.actor.JSONActor
 
 

--- a/docs/sphinx/legacy.rst
+++ b/docs/sphinx/legacy.rst
@@ -127,4 +127,6 @@ Although the internals of parsing and validation are significantly different, th
 JSONActor
 ---------
 
-CLU also provides a simple `.JSONActor` which accepts commands following the same format as legacy actors but replies with a JSON string. This makes the replies more verbose and less human-readable but much more easy to parse, since they can be interpreted by just calling `json.loads` or the equivalent JSON loading routing for any programming language. `.JSONActor` is thus useful for devices that will be commanded by an actor but not directly replying to Tron or a user.
+CLU also provides a simple `.JSONActor` which accepts commands following almost the same format as legacy actors for input commands but replies with a JSON string. This makes the replies more verbose and less human-readable but much more easy to parse, since they can be interpreted by just calling `json.loads` or the equivalent JSON loading routing for any programming language. `.JSONActor` is thus useful for devices that will be commanded by an actor but not directly replying to Tron or a user.
+
+`.JSONActor` is an implementation of `.TCPBaseActor` using a :ref:`Click parser <click-parser>`.

--- a/docs/sphinx/parser.rst
+++ b/docs/sphinx/parser.rst
@@ -154,7 +154,7 @@ There are no ready-to-use actors that implement the JSON parser, but it's trivia
     class AMQPJSONActor(JSONParser, AMQPBaseActor):
         callbacks = {"command1": command1}
 
-Note that the order of the imports is important. `.JSONParser` should be listed before the base actor to make sure that `.BaseActor.parse_command` is overridden. It's also possible to subclass from `.BaseLegacyActor` to use a TCP transport.
+Note that the order of the imports is important. `.JSONParser` should be listed before the base actor to make sure that `.BaseActor.parse_command` is overridden. It's also possible to subclass from `.TCPBaseActor` or `.BaseLegacyActor` to use a TCP transport.
 
 The callbacks for the parser must be coroutines that accept the command as the first arguments and a payload (a dictionary with the deserialised JSON string) as the second one. The mapping of command "verb" to callback is defined in the ``callbacks`` attribute.
 

--- a/python/clu/testing.py
+++ b/python/clu/testing.py
@@ -207,7 +207,7 @@ async def setup_test_actor(actor: T, user_id: int = 1) -> T:
             )
             return self.new_command(message, ack=False)
 
-    actor.start = CoroutineMock(return_value=actor)
+    actor.start = CoroutineMock(return_value=actor)  # type: ignore
 
     # Adds an invoke_mock_command method.
     # We use types.MethodType to bind a method to an existing instance

--- a/python/clu/testing.py
+++ b/python/clu/testing.py
@@ -23,7 +23,7 @@ from aiormq.types import DeliveredMessage
 from pamqp.header import ContentHeader
 
 import clu
-from clu.actor import AMQPBaseActor, JSONActor
+from clu.actor import AMQPBaseActor, TCPBaseActor
 from clu.command import Command
 from clu.legacy.actor import LegacyActor
 
@@ -40,7 +40,7 @@ else:
 __all__ = ["MockReply", "MockReplyList", "setup_test_actor"]
 
 
-class MockedActor(JSONActor, LegacyActor, AMQPBaseActor):
+class MockedActor(TCPBaseActor, LegacyActor, AMQPBaseActor):
     invoke_mock_command: Any
     mock_replies: List[MockReply]
 


### PR DESCRIPTION
Fixes #72. 

It does not create a `JSONBaseActor`. It introduces a `TCPBaseActor` which is almost the same as the old `JSONActor` but without a parser. `JSONActor` is now the version of  `TCPBaseActor` that implements the Click parser.

`BaseLegacyActor` does not subclass from `TCPBaseActor`. There are enough differences in the parsing of new commands that it's not really worth doing that.