### PR TITLE
Check if Tron is connected before sending a command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@
 Changelog
 =========
 
+* :bug:`78` Fixes a bug in which an actor with a defined `.TronConnection` that had failed to start would still try to send commands to Tron.
+
 * :release:`1.0.1 <2021-05-16>`
 * :support:`-` `.BaseActor` receives a ``validate`` parameter that can be used to globally define whether the actor should validate its own messages against the model.
 

--- a/python/clu/legacy/actor.py
+++ b/python/clu/legacy/actor.py
@@ -334,14 +334,13 @@ class BaseLegacyActor(BaseActor):
             know what you're doing.
         """
 
-        if self.tron:
+        if self.tron and self.tron.connected():
             command = self.tron.send_command(
                 target,
                 command_string,
                 commander=f"{self.name}.{self.name}",
                 mid=command_id,
             )
-            # command.actor = self
             return command
 
         else:

--- a/python/clu/legacy/tron.py
+++ b/python/clu/legacy/tron.py
@@ -208,6 +208,14 @@ class TronConnection(BaseClient):
         self._client.close()
         self._parser.cancel()
 
+    def connected(self):
+        """Checks whether the client is connected."""
+
+        if self._client is None:
+            return False
+
+        return not self._client.writer.is_closing()
+
     async def run_forever(self):
 
         # Keep alive until the connection is closed.

--- a/tests/legacy/test_tron.py
+++ b/tests/legacy/test_tron.py
@@ -156,3 +156,12 @@ async def test_reload_model(tron_client):
     tron_client.models["alerts"].reload()
 
     assert tron_client.models["alerts"]["version"].value[0] is None
+
+
+async def test_tron_connected(actor, tron_server):
+
+    assert actor.tron.connected()
+
+    actor.tron._client.writer.close()
+
+    assert actor.tron.connected() is False


### PR DESCRIPTION
Fixes a bug in which an actor with a defined `TronConnection` that failed to start would still try to send commands.