### PR TITLE
Improvements to Command typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Next version
+
+### ✨ Improved
+
+* [#81](https://github.com/sdss/clu/issues/81) Improve typing of `BaseCommand` and command replies.
+
+
 ## 1.0.3 - May 20, 2021
 
 ### ✨ Improved
@@ -16,7 +23,7 @@
 
 ### ✨ Improved
 
-* [#78](https://github.com/sdss/clu/issues/79): `TronConnection` now uses a `ReconnectingTCPClientProtocol` that will try to keep the socket to Tron open, allowing Tron to restart without losing connection.
+* [#79](https://github.com/sdss/clu/issues/79): `TronConnection` now uses a `ReconnectingTCPClientProtocol` that will try to keep the socket to Tron open, allowing Tron to restart without losing connection.
 
 ### 🧹 Cleanup
 

--- a/python/clu/client.py
+++ b/python/clu/client.py
@@ -67,12 +67,14 @@ class AMQPReply(object):
         log: Optional[logging.Logger] = None,
     ):
 
+        self.command_id: int | None = None
+        self.sender: str | None = None
+        self.body = {}
+
         self.message = message
-        self.log = log
+        self._log = log
 
         self.is_valid = True
-
-        self.body = None
 
         # Acknowledges receipt of message
         message.ack()
@@ -88,20 +90,20 @@ class AMQPReply(object):
 
         if self.message_code is None:
             self.is_valid = False
-            if self.log:
-                self.log.warning(f"received message without message_code: {message}")
+            if self._log:
+                self._log.warning(f"received message without message_code: {message}")
             return
 
         self.sender = self.headers.get("sender", None)
-        if self.sender is None and self.log:
-            self.log.warning(f"received message without sender: {message}")
+        if self.sender is None and self._log:
+            self._log.warning(f"received message without sender: {message}")
 
         self.command_id = message.correlation_id
 
         command_id_header = self.headers.get("command_id", None)
         if command_id_header and command_id_header != self.command_id:
-            if self.log:
-                self.log.error(
+            if self._log:
+                self._log.error(
                     f"mismatch between message "
                     f"correlation_id={self.command_id} "
                     f"and header command_id={command_id_header} "

--- a/python/clu/client.py
+++ b/python/clu/client.py
@@ -315,7 +315,7 @@ class AMQPClient(BaseClient):
         command_id = command_id or str(uuid.uuid4())
 
         # Creates and registers a command.
-        command = Command(
+        command: Command[AMQPClient] = Command(
             command_string=command_string,
             command_id=command_id,
             commander_id=self.name,

--- a/python/clu/command.py
+++ b/python/clu/command.py
@@ -34,7 +34,7 @@ Client_co = TypeVar("Client_co", bound="clu.base.BaseClient", covariant=True)
 Future_co = TypeVar("Future_co", bound="BaseCommand", covariant=True)
 
 
-if sys.version_info > (3, 8):
+if sys.version_info >= (3, 9, 0):
     Future = asyncio.Future
 else:
 

--- a/python/clu/command.py
+++ b/python/clu/command.py
@@ -29,10 +29,10 @@ __all__ = [
 ]
 
 
-Actor_co = TypeVar("Actor_co", bound="clu.base.BaseActor", covariant=True)
+Client_co = TypeVar("Client_co", bound="clu.base.BaseClient", covariant=True)
 
 
-class BaseCommand(asyncio.Future, StatusMixIn[CommandStatus], Generic[Actor_co]):
+    Generic[Client_co],
     """Base class for commands of all types (user and device).
 
     A `BaseCommand` instance is a `~asyncio.Future` whose result gets set
@@ -73,8 +73,8 @@ class BaseCommand(asyncio.Future, StatusMixIn[CommandStatus], Generic[Actor_co])
         commander_id: Union[int, str] = 0,
         command_id: Union[int, str] = 0,
         consumer_id: Union[int, str] = 0,
-        actor: Optional[Actor_co] = None,
-        parent: Optional[BaseCommand[Actor_co]] = None,
+        actor: Optional[clu.base.BaseActor] = None,
+        parent: Optional[BaseCommand[Client_co]] = None,
         status_callback: Optional[Callable[[CommandStatus], Any]] = None,
         call_now: bool = False,
         default_keyword: str = "text",
@@ -253,7 +253,7 @@ class BaseCommand(asyncio.Future, StatusMixIn[CommandStatus], Generic[Actor_co])
         )
 
 
-class Command(BaseCommand[Actor_co]):
+class Command(BaseCommand[Client_co]):
     """A command from a user.
 
     Parameters

--- a/python/clu/command.py
+++ b/python/clu/command.py
@@ -42,7 +42,11 @@ else:
         pass
 
 
-class BaseCommand(Future, StatusMixIn[CommandStatus], Generic[Client_co, Future_co]):
+class BaseCommand(
+    Future[Future_co],
+    StatusMixIn[CommandStatus],
+    Generic[Client_co, Future_co],
+):
     """Base class for commands of all types (user and device).
 
     A `BaseCommand` instance is a `~asyncio.Future` whose result gets set

--- a/python/clu/command.py
+++ b/python/clu/command.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import re
+import sys
 import time
 from contextlib import suppress
 
@@ -33,11 +34,15 @@ Client_co = TypeVar("Client_co", bound="clu.base.BaseClient", covariant=True)
 Future_co = TypeVar("Future_co", bound="BaseCommand", covariant=True)
 
 
-class BaseCommand(
-    asyncio.Future[Future_co],
-    StatusMixIn[CommandStatus],
-    Generic[Client_co, Future_co],
-):
+if sys.version_info > (3, 8):
+    Future = asyncio.Future
+else:
+
+    class Future(asyncio.Future, Generic[Future_co]):
+        pass
+
+
+class BaseCommand(Future, StatusMixIn[CommandStatus], Generic[Client_co, Future_co]):
     """Base class for commands of all types (user and device).
 
     A `BaseCommand` instance is a `~asyncio.Future` whose result gets set

--- a/python/clu/command.py
+++ b/python/clu/command.py
@@ -91,8 +91,9 @@ Client_co = TypeVar("Client_co", bound="clu.base.BaseClient", covariant=True)
         self.default_keyword = default_keyword
         self.loop = loop or asyncio.get_event_loop()
 
-        #: .Reply: A list of replies this command has received.
-        self.replies: List[clu.base.Reply] = []
+        #: A list of replies this command has received. The type of
+        #: reply object dependson the actor or client issuing the command.
+        self.replies: List[Any] = []
 
         asyncio.Future.__init__(self, loop=self.loop)
 

--- a/python/clu/command.py
+++ b/python/clu/command.py
@@ -30,9 +30,14 @@ __all__ = [
 
 
 Client_co = TypeVar("Client_co", bound="clu.base.BaseClient", covariant=True)
+Future_co = TypeVar("Future_co", bound="BaseCommand", covariant=True)
 
 
-    Generic[Client_co],
+class BaseCommand(
+    asyncio.Future[Future_co],
+    StatusMixIn[CommandStatus],
+    Generic[Client_co, Future_co],
+):
     """Base class for commands of all types (user and device).
 
     A `BaseCommand` instance is a `~asyncio.Future` whose result gets set
@@ -74,7 +79,7 @@ Client_co = TypeVar("Client_co", bound="clu.base.BaseClient", covariant=True)
         command_id: Union[int, str] = 0,
         consumer_id: Union[int, str] = 0,
         actor: Optional[clu.base.BaseActor] = None,
-        parent: Optional[BaseCommand[Client_co]] = None,
+        parent: Optional[BaseCommand[Client_co, Future_co]] = None,
         status_callback: Optional[Callable[[CommandStatus], Any]] = None,
         call_now: bool = False,
         default_keyword: str = "text",
@@ -254,7 +259,7 @@ Client_co = TypeVar("Client_co", bound="clu.base.BaseClient", covariant=True)
         )
 
 
-class Command(BaseCommand[Client_co]):
+class Command(BaseCommand[Client_co, "Command"]):
     """A command from a user.
 
     Parameters

--- a/python/clu/legacy/tron.py
+++ b/python/clu/legacy/tron.py
@@ -269,7 +269,7 @@ class TronConnection(BaseClient):
 
         command_string = f"{commander} {mid} {target} {command_string}\n"
 
-        command = Command(command_string=command_string)
+        command: Command[TronConnection] = Command(command_string=command_string)
         command.set_status("RUNNING")
         self.running_commands[mid] = command
 


### PR DESCRIPTION
- Adds typing to the result of the `BaseCommand` Future.
- Better typing of `AMQPReply`.
- Set `BaseCommand.replies` to a list of `Any` since we cannot set it dynamically and the reply types are too different.