### PR TITLE
Cast all arguments to string in ProxyClient.send_command()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Next release
+
+### ✨ Improved
+
+* [#95](https://github.com/sdss/clu/issues/95) Cast all arguments to string in `ProxyClient.send_command()`.
+
+
 ## 1.3.0 - September 17, 2021
 
 ### 💥 Breaking changes

--- a/python/clu/base.py
+++ b/python/clu/base.py
@@ -298,7 +298,7 @@ class ProxyClient:
 
         """
 
-        command = " ".join(args)
+        command = " ".join(map(str, args))
 
         return self.client.send_command(self.actor, command)
 


### PR DESCRIPTION
Fixes #95