### PR TITLE
Add tron-reconnect command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Next version
+
+### 🚀 New
+
+* [#111](https://github.com/sdss/clu/issues/111) If a `LegacyActor` uses the Click parser, and a connection to Tron is defined, adds a `tron-reconnect` command that can be used to force recreating the connection from the actor to Tron.
+
+
 ## 1.8.2 - September 15, 2022
 
 ### 🔧 Fixed

--- a/python/clu/legacy/actor.py
+++ b/python/clu/legacy/actor.py
@@ -23,7 +23,7 @@ from ..command import Command, TimedCommandList, parse_legacy_command
 from ..parsers import ClickParser
 from ..protocol import TCPStreamServer
 from ..tools import log_reply
-from .tron import TronConnection
+from .tron import TronConnection, tron_reconnect
 from .types.messages import Reply as OpsReply
 
 
@@ -531,3 +531,10 @@ class BaseLegacyActor(BaseActor):
 
 class LegacyActor(ClickParser, BaseLegacyActor):
     """A legacy actor that uses the `.ClickParser`."""
+
+    def __init__(self, *args, **kwargs):
+
+        super().__init__(*args, **kwargs)
+
+        if self.tron:
+            self.parser.add_command(tron_reconnect)

--- a/python/clu/legacy/tron.py
+++ b/python/clu/legacy/tron.py
@@ -21,6 +21,7 @@ import clu.base
 from clu.command import Command, CommandStatus
 from clu.exceptions import CluWarning
 from clu.model import BaseModel, Property
+from clu.parsers.click import command_parser
 from clu.protocol import ReconnectingTCPClientProtocol
 
 from .types.keys import Key, KeysDictionary
@@ -29,6 +30,23 @@ from .types.parser import ParseError, ReplyParser
 
 
 __all__ = ["TronConnection", "TronModel", "TronKey"]
+
+
+@command_parser.command(name="tron-reconnect")
+async def tron_reconnect(*args):
+    """Pings the actor."""
+
+    command = args[0]
+
+    if command.actor.tron is None:
+        return command.fail("Tron instance not set.")
+
+    command.actor.tron.stop()
+    await asyncio.sleep(0.5)
+
+    await command.actor.tron.start()
+
+    return command.finish()
 
 
 class TronKey(Property):

--- a/tests/legacy/test_tron.py
+++ b/tests/legacy/test_tron.py
@@ -181,3 +181,20 @@ async def test_client_send_command_args(tron_server, actor):
     assert b"alerts ping --help" in tron_server.received[-1]
 
     assert len(command.replies) == 1
+
+
+async def test_tron_reconnect_command(actor, tron_server):
+
+    assert actor.tron.connected()
+    assert "tron-reconnect" in actor.parser.commands
+
+    actor.tron.transport.close()
+    assert actor.tron.connected() is False
+
+    reader, writer = await asyncio.open_connection(actor.host, actor.port)
+    writer.write(b"tron-reconnect\n")
+    await writer.drain()
+
+    await asyncio.sleep(1)
+
+    assert actor.tron.connected()


### PR DESCRIPTION
If a `LegacyActor` uses the Click parser, and a connection to Tron is defined, adds a `tron-reconnect` command that can be used to force recreating the connection from the actor to Tron.