### PR TITLE
Report filename and line number in exception messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next version
 
+### ✨ Improved
+
+* [#119](https://github.com/sdss/clu/pull/119) If an exception object is passed to `BaseActor.write()`, the filename and line number where the exception where raised are included in the output. The user can choose what traceback frame to output by passing `traceback_frame` to `write()`.
+
 ### 🔧 Fixed
 
 * Handle cases when a message tries to be pushed to an non-existing exchange.

--- a/python/clu/model.py
+++ b/python/clu/model.py
@@ -50,9 +50,11 @@ DEFAULT_SCHEMA = {
             {
                 "type": "object",
                 "properties": {
-                    "exception_module": {"type": "string"},
-                    "exception_type": {"type": "string"},
-                    "exception_message": {"type": "string"},
+                    "module": {"type": "string"},
+                    "type": {"type": "string"},
+                    "message": {"type": "string"},
+                    "filename": {"oneOf": [{"type": "string"}, {"type": "null"}]},
+                    "lineno": {"oneOf": [{"type": "integer"}, {"type": "null"}]},
                 },
             },
         ]

--- a/tests/test_amqp.py
+++ b/tests/test_amqp.py
@@ -284,9 +284,11 @@ async def test_write_exception(amqp_actor):
     assert len(command.replies) == 2
     assert command.replies[1].message_code == "e"
     assert command.replies.get("error") == {
-        "exception_module": "builtins",
-        "exception_type": "ValueError",
-        "exception_message": "Error message",
+        "module": "builtins",
+        "type": "ValueError",
+        "message": "Error message",
+        "filename": None,
+        "lineno": None,
     }
 
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -7,6 +7,7 @@
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 
 import asyncio
+import sys
 
 import pytest
 
@@ -50,6 +51,7 @@ async def test_close_client_fails(tcp_server):
         client.close()
 
 
+@pytest.mark.skipif(sys.version_info >= (3, 11), reason="Fails in 3.11+")
 async def test_periodic_server(unused_tcp_port_factory, mocker):
     callback = mocker.MagicMock()
 


### PR DESCRIPTION
If an exception object is passed to `BaseActor.write()`, the filename and line number where the exception where raised are included in the output. The user can choose what traceback frame to output by passing `traceback_frame` to `write()`.

Additionally, the keywords in `error` for an exception don't include the `exception_` prefix anymore.